### PR TITLE
UTF8 caracters bug

### DIFF
--- a/lib/runkeeperAPI.class.php
+++ b/lib/runkeeperAPI.class.php
@@ -221,6 +221,7 @@ class RunKeeperAPI {
 			}
 			else {
 				if ($responsecode === 200) {
+					$response = utf8_encode($response);
 					$response = htmlentities($response,ENT_NOQUOTES);
 					$decoderesponse = json_decode($response);
 					$this->api_request_log[] = array('name' => $name, 'type' => $type, 'result' => 200, 'responsecode' => $responsecode, 'time' => microtime(true)-$orig);


### PR DESCRIPTION
There's a problem with utf-8 caracters returned by the RunKeeper API.
You can test it by adding a "é" in your name and try to do a Profile READ. It won't work.
Theses caracters are not properly parsed.
